### PR TITLE
Adding Garron.me blog, with Linux How-Tos

### DIFF
--- a/sites/blogs.txt
+++ b/sites/blogs.txt
@@ -45,3 +45,4 @@ https://acolyer.org
 https://wasmbyexample.dev
 https://ohshitgit.com
 https://www.toptal.com/developers
+https://www.garron.me/en/


### PR DESCRIPTION
Blog added, 

https://www.garron.me/en/